### PR TITLE
Add query parameters to get portfolio link API

### DIFF
--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -1292,7 +1292,83 @@
       "get": {
         "operationId": "MagicLinksController_getLink",
         "summary": "Get portfolio link",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "per_page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 10,
+              "type": "number"
+            }
+          },
+          {
+            "name": "active",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            }
+          },
+          {
+            "name": "property_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "application_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "email",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "property_external_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_external_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1470,6 +1546,22 @@
           },
           {
             "name": "external_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "property_external_id",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_external_id",
             "required": false,
             "in": "query",
             "schema": {
@@ -2886,6 +2978,11 @@
             "type": "string",
             "example": "123",
             "nullable": true
+          },
+          "listing_id": {
+            "type": "string",
+            "example": "123",
+            "nullable": true
           }
         },
         "required": [
@@ -3470,6 +3567,10 @@
             "format": "date-time",
             "type": "string",
             "example": "2021-01-01T00:00:00.000Z"
+          },
+          "application_url": {
+            "type": "string",
+            "example": "https://boompay.app/applications/1234567890"
           }
         },
         "required": [


### PR DESCRIPTION
This pull request introduces several changes to the `screening-api-docs/api.json` file, primarily focused on enhancing the API's query parameters and response schemas. The key changes include adding new optional query parameters to the `MagicLinksController_getLink` operation and extending the response schemas with additional fields.

Enhancements to query parameters:

* Added new optional query parameters `page`, `per_page`, `active`, `property_id`, `unit_id`, `application_id`, `email`, `property_external_id`, and `unit_external_id` to the `MagicLinksController_getLink` operation.
* Added new optional query parameters `property_external_id` and `unit_external_id` to another operation.

Extensions to response schemas:

* Added `listing_id` field to the response schema, allowing it to be nullable.
* Added `application_url` field to the response schema, providing an example URL.