### PR TITLE
[CRM-540] Add assignees to application schemas

### DIFF
--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -6284,6 +6284,26 @@
           "updated_at"
         ]
       },
+      "Assignee": {
+        "type": "object",
+        "description": "A partner user assigned to an application",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "abc123",
+            "description": "Obfuscated partner user ID"
+          },
+          "email": {
+            "type": "string",
+            "example": "user@example.com"
+          },
+          "name": {
+            "type": "string",
+            "example": "John Doe"
+          }
+        },
+        "required": ["id", "email", "name"]
+      },
       "ApplicantList": {
         "type": "object",
         "properties": {
@@ -6647,6 +6667,13 @@
             "items": {
               "type": "string"
             }
+          },
+          "assignees": {
+            "type": "array",
+            "description": "List of partner users assigned to this application",
+            "items": {
+              "$ref": "#/components/schemas/Assignee"
+            }
           }
         },
         "required": [
@@ -6804,6 +6831,13 @@
             "type": "array",
             "items": {
               "type": "string"
+            }
+          },
+          "assignees": {
+            "type": "array",
+            "description": "List of partner users assigned to this application",
+            "items": {
+              "$ref": "#/components/schemas/Assignee"
             }
           },
           "pet_rent_value": {


### PR DESCRIPTION
### Related ticket

https://boompay.atlassian.net/browse/CRM-540

### Description

Added `Assignee` schema and `assignees` array field to both `ApplicationList` and `ApplicationDetail` OpenAPI schemas.

Related API PR: boompay/boompay-api#3935

---

### Release tester notes

Verify the API docs render the new `assignees` field correctly for application endpoints.