### PR TITLE
add GET /partner/v1/leads/identity_verifications endpoint

### DIFF
--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -4899,12 +4899,20 @@
         ]
       }
     },
-    "/partner/v1/leads/identity_verifications": {
+    "/partner/v1/leads/{lead_id}/identity_verification": {
       "get": {
-        "operationId": "LeadsController_getIdentityVerifications",
-        "summary": "Get IDV results for all leads",
-        "description": "Returns all identity verification results for the partner's leads. Supports pagination and scoped API key restrictions.",
+        "operationId": "LeadsController_getLeadIdentityVerifications",
+        "summary": "Get identity verifications for a lead",
+        "description": "Returns all identity verification results for the specified lead. Supports pagination.",
         "parameters": [
+          {
+            "name": "lead_id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "page",
             "required": false,
@@ -4951,6 +4959,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
           }
         },
         "tags": [

--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -4899,7 +4899,7 @@
         ]
       }
     },
-    "/partner/v1/leads/{lead_id}/identity_verification": {
+    "/partner/v1/leads/{lead_id}/identity_verifications": {
       "get": {
         "operationId": "LeadsController_getLeadIdentityVerifications",
         "summary": "Get identity verifications for a lead",
@@ -10707,10 +10707,57 @@
             "type": "string",
             "description": "Obfuscated lead ID"
           },
-          "lead_external_id": {
+          "first_name": {
+            "type": "string",
+            "description": "Lead first name"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "Lead last name"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true,
+            "description": "Lead primary email"
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true,
+            "description": "Lead primary phone"
+          },
+          "external_id": {
             "type": "string",
             "nullable": true,
             "description": "External ID of the lead as provided by the partner"
+          },
+          "external_customer_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "External customer ID (same as external_id)"
+          },
+          "property_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Obfuscated property ID"
+          },
+          "unit_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Obfuscated unit ID"
+          },
+          "application_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Obfuscated application ID associated with the lead"
+          },
+          "applicant_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Obfuscated applicant ID associated with the lead"
+          },
+          "identity_verification_finished": {
+            "type": "boolean",
+            "description": "Whether the lead has a finished identity verification"
           },
           "provider": {
             "type": "string",

--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -67,7 +67,9 @@
             }
           }
         },
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/partner/v1/users": {
@@ -137,7 +139,9 @@
             }
           }
         },
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "bearer": []
@@ -231,7 +235,9 @@
             }
           }
         },
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "bearer": []
@@ -315,7 +321,9 @@
             }
           }
         },
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "bearer": []
@@ -387,7 +395,9 @@
             }
           }
         },
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "bearer": []
@@ -452,7 +462,9 @@
             }
           }
         },
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "bearer": []
@@ -548,7 +560,9 @@
             }
           }
         },
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "security": [
           {
             "bearer": []
@@ -621,7 +635,9 @@
             }
           }
         },
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "security": [
           {
             "bearer": []
@@ -695,7 +711,9 @@
             }
           }
         },
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "security": [
           {
             "bearer": []
@@ -777,7 +795,9 @@
             }
           }
         },
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "security": [
           {
             "bearer": []
@@ -842,7 +862,9 @@
             }
           }
         },
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "security": [
           {
             "bearer": []
@@ -948,7 +970,9 @@
             }
           }
         },
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "security": [
           {
             "bearer": []
@@ -1018,7 +1042,9 @@
             }
           }
         },
-        "tags": ["Bank Accounts"],
+        "tags": [
+          "Bank Accounts"
+        ],
         "security": [
           {
             "bearer": []
@@ -1094,7 +1120,9 @@
             }
           }
         },
-        "tags": ["Bank Accounts"],
+        "tags": [
+          "Bank Accounts"
+        ],
         "security": [
           {
             "bearer": []
@@ -1206,7 +1234,9 @@
             }
           }
         },
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "security": [
           {
             "bearer": []
@@ -1279,7 +1309,9 @@
             }
           }
         },
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "security": [
           {
             "bearer": []
@@ -1353,7 +1385,9 @@
             }
           }
         },
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "security": [
           {
             "bearer": []
@@ -1435,7 +1469,9 @@
             }
           }
         },
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "security": [
           {
             "bearer": []
@@ -1500,7 +1536,9 @@
             }
           }
         },
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "security": [
           {
             "bearer": []
@@ -1537,7 +1575,10 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": [
+                "true",
+                "false"
+              ]
             }
           },
           {
@@ -1646,7 +1687,9 @@
             }
           }
         },
-        "tags": ["Magic links"],
+        "tags": [
+          "Magic links"
+        ],
         "security": [
           {
             "bearer": []
@@ -1720,7 +1763,9 @@
             }
           }
         },
-        "tags": ["Magic links"],
+        "tags": [
+          "Magic links"
+        ],
         "security": [
           {
             "bearer": []
@@ -1872,7 +1917,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -1946,7 +1993,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2028,7 +2077,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2110,7 +2161,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2210,7 +2263,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2292,7 +2347,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2382,7 +2439,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2480,7 +2539,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2514,7 +2575,9 @@
                     "description": "Whether to refund the application upon cancellation"
                   }
                 },
-                "required": ["refund"]
+                "required": [
+                  "refund"
+                ]
               }
             }
           }
@@ -2591,7 +2654,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2665,7 +2730,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -2793,7 +2860,9 @@
             }
           }
         },
-        "tags": ["Applicants"],
+        "tags": [
+          "Applicants"
+        ],
         "security": [
           {
             "bearer": []
@@ -2875,7 +2944,9 @@
             }
           }
         },
-        "tags": ["Applicants"],
+        "tags": [
+          "Applicants"
+        ],
         "security": [
           {
             "bearer": []
@@ -2962,7 +3033,9 @@
             }
           }
         },
-        "tags": ["Applicants"],
+        "tags": [
+          "Applicants"
+        ],
         "security": [
           {
             "bearer": []
@@ -3044,7 +3117,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -3127,7 +3202,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -3215,7 +3292,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -3316,7 +3395,9 @@
             }
           }
         },
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "security": [
           {
             "bearer": []
@@ -3422,7 +3503,9 @@
             }
           }
         },
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "security": [
           {
             "bearer": []
@@ -3495,7 +3578,9 @@
             }
           }
         },
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "security": [
           {
             "bearer": []
@@ -3573,7 +3658,9 @@
             }
           }
         },
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "security": [
           {
             "bearer": []
@@ -3718,7 +3805,9 @@
             }
           }
         },
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "security": [
           {
             "bearer": []
@@ -4070,7 +4159,9 @@
             }
           }
         },
-        "tags": ["Stages"],
+        "tags": [
+          "Stages"
+        ],
         "security": [
           {
             "bearer": []
@@ -4128,7 +4219,9 @@
             }
           }
         },
-        "tags": ["Lead Sources"],
+        "tags": [
+          "Lead Sources"
+        ],
         "security": [
           {
             "bearer": []
@@ -4228,7 +4321,9 @@
             }
           }
         },
-        "tags": ["Lead Sources"],
+        "tags": [
+          "Lead Sources"
+        ],
         "security": [
           {
             "bearer": []
@@ -4696,7 +4791,9 @@
             }
           }
         },
-        "tags": ["Activity Logs"],
+        "tags": [
+          "Activity Logs"
+        ],
         "security": [
           {
             "bearer": []
@@ -4792,7 +4889,73 @@
             }
           }
         },
-        "tags": ["Activity Logs"],
+        "tags": [
+          "Activity Logs"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/partner/v1/leads/identity_verifications": {
+      "get": {
+        "operationId": "LeadsController_getIdentityVerifications",
+        "summary": "Get IDV results for all leads",
+        "description": "Returns all identity verification results for the partner's leads. Supports pagination and scoped API key restrictions.",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "per_page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedResponse"
+                    },
+                    {
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/LeadIdentityVerification"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Leads"
+        ],
         "security": [
           {
             "bearer": []
@@ -4858,10 +5021,17 @@
                 ]
               }
             },
-            "required": ["status", "message", "code", "errors"]
+            "required": [
+              "status",
+              "message",
+              "code",
+              "errors"
+            ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "TooManyRequestsResponse": {
         "type": "object",
@@ -4871,7 +5041,9 @@
             "example": "Too many requests. Please try again later."
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "InternalErrorResponse": {
         "type": "object",
@@ -4900,10 +5072,16 @@
                 "example": "abc123def456"
               }
             },
-            "required": ["status", "message", "code"]
+            "required": [
+              "status",
+              "message",
+              "code"
+            ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "AuthenticationRequest": {
         "type": "object",
@@ -4917,7 +5095,10 @@
             "example": "secret_key"
           }
         },
-        "required": ["access_key", "secret_key"]
+        "required": [
+          "access_key",
+          "secret_key"
+        ]
       },
       "AuthenticationResponse": {
         "type": "object",
@@ -4927,7 +5108,9 @@
             "example": "auth_token"
           }
         },
-        "required": ["auth_token"]
+        "required": [
+          "auth_token"
+        ]
       },
       "Unauthorized": {
         "type": "object",
@@ -4948,10 +5131,16 @@
                 "example": "unauthenticated"
               }
             },
-            "required": ["status", "message", "code"]
+            "required": [
+              "status",
+              "message",
+              "code"
+            ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "CreateUser": {
         "type": "object",
@@ -4970,7 +5159,10 @@
             "default": "property_manager"
           }
         },
-        "required": ["name", "email"]
+        "required": [
+          "name",
+          "email"
+        ]
       },
       "Address": {
         "type": "object",
@@ -5077,7 +5269,12 @@
             "example": "2021-01-01T00:00:00.000Z"
           }
         },
-        "required": ["id", "active", "link", "created_at"]
+        "required": [
+          "id",
+          "active",
+          "link",
+          "created_at"
+        ]
       },
       "Money": {
         "type": "object",
@@ -5092,7 +5289,9 @@
             "default": "USD"
           }
         },
-        "required": ["cents"]
+        "required": [
+          "cents"
+        ]
       },
       "RuleSet": {
         "type": "object",
@@ -5100,7 +5299,10 @@
           "rule_set_type": {
             "type": "string",
             "example": "approve",
-            "enum": ["approve", "decline"]
+            "enum": [
+              "approve",
+              "decline"
+            ]
           },
           "rules": {
             "type": "array",
@@ -5135,7 +5337,11 @@
                   "type": "string",
                   "example": null,
                   "nullable": true,
-                  "enum": ["percentage", "numeric", "within_N_years"]
+                  "enum": [
+                    "percentage",
+                    "numeric",
+                    "within_N_years"
+                  ]
                 },
                 "group_type": {
                   "type": "string",
@@ -5176,7 +5382,14 @@
                 "operator": {
                   "type": "string",
                   "example": ">=",
-                  "enum": [">=", "<=", ">", "<", "==", "!="]
+                  "enum": [
+                    ">=",
+                    "<=",
+                    ">",
+                    "<",
+                    "==",
+                    "!="
+                  ]
                 }
               }
             }
@@ -5238,7 +5451,10 @@
             "$ref": "#/components/schemas/VerificationSchemaType"
           }
         },
-        "required": ["applicant", "co_signer"]
+        "required": [
+          "applicant",
+          "co_signer"
+        ]
       },
       "VerificationScreeningCriteria": {
         "type": "object",
@@ -5454,7 +5670,12 @@
             "example": "2021-01-01T00:00:00.000Z"
           }
         },
-        "required": ["id", "name", "verification_template_id", "created_at"]
+        "required": [
+          "id",
+          "name",
+          "verification_template_id",
+          "created_at"
+        ]
       },
       "User": {
         "type": "object",
@@ -5536,7 +5757,12 @@
             }
           }
         },
-        "required": ["id", "name", "email", "role"]
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role"
+        ]
       },
       "UpdateUser": {
         "type": "object",
@@ -5607,7 +5833,12 @@
             "example": false
           }
         },
-        "required": ["total_count", "page_count", "current_page", "has_more"]
+        "required": [
+          "total_count",
+          "page_count",
+          "current_page",
+          "has_more"
+        ]
       },
       "ActivityLog": {
         "type": "object",
@@ -5650,7 +5881,15 @@
             "example": "2025-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "application_id", "event_type", "event_description", "actor", "details", "occurred_at"]
+        "required": [
+          "id",
+          "application_id",
+          "event_type",
+          "event_description",
+          "actor",
+          "details",
+          "occurred_at"
+        ]
       },
       "ActivityLogActor": {
         "type": "object",
@@ -5659,7 +5898,12 @@
           "type": {
             "type": "string",
             "description": "The type of actor",
-            "enum": ["partner_user", "applicant", "partner", "system"],
+            "enum": [
+              "partner_user",
+              "applicant",
+              "partner",
+              "system"
+            ],
             "example": "partner_user"
           },
           "name": {
@@ -5673,7 +5917,10 @@
             "example": "admin"
           }
         },
-        "required": ["type", "name"]
+        "required": [
+          "type",
+          "name"
+        ]
       },
       "NotFoundResponse": {
         "type": "object",
@@ -5694,10 +5941,16 @@
                 "example": "not_found"
               }
             },
-            "required": ["status", "message", "code"]
+            "required": [
+              "status",
+              "message",
+              "code"
+            ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "UnitList": {
         "type": "object",
@@ -5847,7 +6100,13 @@
             "description": "The ID of the bank account associated with this property (only applicable for partners with per_property billing)"
           }
         },
-        "required": ["id", "address", "created_at", "updated_at", "units"]
+        "required": [
+          "id",
+          "address",
+          "created_at",
+          "updated_at",
+          "units"
+        ]
       },
       "CreateAddress": {
         "type": "object",
@@ -5874,7 +6133,12 @@
             "example": "12345"
           }
         },
-        "required": ["address1", "city", "state_or_province", "postal_code"]
+        "required": [
+          "address1",
+          "city",
+          "state_or_province",
+          "postal_code"
+        ]
       },
       "CreatePropertyUnit": {
         "type": "object",
@@ -5985,7 +6249,9 @@
             "nullable": true
           }
         },
-        "required": ["address"]
+        "required": [
+          "address"
+        ]
       },
       "ForbiddenErrorResponse": {
         "type": "object",
@@ -6006,10 +6272,16 @@
                 "example": "forbidden"
               }
             },
-            "required": ["status", "message", "code"]
+            "required": [
+              "status",
+              "message",
+              "code"
+            ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "UpdateProperty": {
         "type": "object",
@@ -6147,7 +6419,11 @@
             "nullable": true
           }
         },
-        "required": ["title", "property_id", "occupied"]
+        "required": [
+          "title",
+          "property_id",
+          "occupied"
+        ]
       },
       "UpdateUnit": {
         "type": "object",
@@ -6192,7 +6468,9 @@
             "example": true
           }
         },
-        "required": ["active"]
+        "required": [
+          "active"
+        ]
       },
       "VerificationProgress": {
         "type": "object",
@@ -6206,7 +6484,10 @@
             "example": 5
           }
         },
-        "required": ["total_steps", "filled_steps"]
+        "required": [
+          "total_steps",
+          "filled_steps"
+        ]
       },
       "VerificationList": {
         "type": "object",
@@ -6302,7 +6583,11 @@
             "example": "John Doe"
           }
         },
-        "required": ["id", "email", "name"]
+        "required": [
+          "id",
+          "email",
+          "name"
+        ]
       },
       "ApplicantList": {
         "type": "object",
@@ -6338,7 +6623,10 @@
           "role": {
             "type": "string",
             "example": "applicant",
-            "enum": ["applicant", "co_signer"]
+            "enum": [
+              "applicant",
+              "co_signer"
+            ]
           },
           "invited_at": {
             "format": "date-time",
@@ -6447,7 +6735,10 @@
           "role": {
             "type": "string",
             "example": "applicant",
-            "enum": ["applicant", "co_signer"]
+            "enum": [
+              "applicant",
+              "co_signer"
+            ]
           },
           "invited_at": {
             "format": "date-time",
@@ -6610,7 +6901,11 @@
             "example": "decline",
             "nullable": true,
             "description": "The application recommendation. Returns null if any submitted applicant has a failed identity verification that has not been manually overridden.",
-            "enum": ["approve", "conditional_approve", "decline"]
+            "enum": [
+              "approve",
+              "conditional_approve",
+              "decline"
+            ]
           },
           "decision_at": {
             "format": "date-time",
@@ -6662,7 +6957,9 @@
             "example": "https://boompay.app/applications/1234567890"
           },
           "adverse_action_reasons": {
-            "example": ["condition"],
+            "example": [
+              "condition"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -6775,7 +7072,11 @@
             "example": "decline",
             "nullable": true,
             "description": "The application recommendation. Returns null if any submitted applicant has a failed identity verification that has not been manually overridden.",
-            "enum": ["approve", "conditional_approve", "decline"]
+            "enum": [
+              "approve",
+              "conditional_approve",
+              "decline"
+            ]
           },
           "decision_at": {
             "format": "date-time",
@@ -6827,7 +7128,9 @@
             "example": "https://boompay.app/applications/1234567890"
           },
           "adverse_action_reasons": {
-            "example": ["condition"],
+            "example": [
+              "condition"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -6885,7 +7188,9 @@
         "type": "object",
         "properties": {
           "conditions": {
-            "example": ["condition"],
+            "example": [
+              "condition"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -6917,7 +7222,9 @@
         "type": "object",
         "properties": {
           "reasons": {
-            "example": ["reason"],
+            "example": [
+              "reason"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -6936,7 +7243,9 @@
             "example": "note message"
           }
         },
-        "required": ["reasons"]
+        "required": [
+          "reasons"
+        ]
       },
       "RentalApplicationEmergencyContact": {
         "type": "object",
@@ -6954,7 +7263,11 @@
             "example": "1234567890"
           }
         },
-        "required": ["last_name", "first_name", "phone_number"]
+        "required": [
+          "last_name",
+          "first_name",
+          "phone_number"
+        ]
       },
       "RentalApplicationReport": {
         "type": "object",
@@ -7070,7 +7383,10 @@
             "example": "Apartment"
           }
         },
-        "required": ["rent", "housing_type"]
+        "required": [
+          "rent",
+          "housing_type"
+        ]
       },
       "HouseHistoryReport": {
         "type": "object",
@@ -7113,7 +7429,10 @@
             "example": "123456789"
           }
         },
-        "required": ["type", "value"]
+        "required": [
+          "type",
+          "value"
+        ]
       },
       "Asset": {
         "type": "object",
@@ -7139,7 +7458,13 @@
             "example": "jpg"
           }
         },
-        "required": ["url", "content_type", "filename", "size", "extension"]
+        "required": [
+          "url",
+          "content_type",
+          "filename",
+          "size",
+          "extension"
+        ]
       },
       "File": {
         "type": "object",
@@ -7148,7 +7473,9 @@
             "$ref": "#/components/schemas/Asset"
           }
         },
-        "required": ["asset"]
+        "required": [
+          "asset"
+        ]
       },
       "IdentityVerificationDocuments": {
         "type": "object",
@@ -7163,7 +7490,11 @@
             "$ref": "#/components/schemas/File"
           }
         },
-        "required": ["face", "original_front", "original_back"]
+        "required": [
+          "face",
+          "original_front",
+          "original_back"
+        ]
       },
       "IdentityVerificationReport": {
         "type": "object",
@@ -7362,7 +7693,11 @@
             }
           }
         },
-        "required": ["message", "consumer_statement", "results"]
+        "required": [
+          "message",
+          "consumer_statement",
+          "results"
+        ]
       },
       "CriminalReportSubject": {
         "type": "object",
@@ -7485,7 +7820,12 @@
             "nullable": true
           }
         },
-        "required": ["case_number", "state", "jurisdiction", "comments"]
+        "required": [
+          "case_number",
+          "state",
+          "jurisdiction",
+          "comments"
+        ]
       },
       "CriminalReportOffense": {
         "type": "object",
@@ -7623,7 +7963,11 @@
             }
           }
         },
-        "required": ["subject", "case_details", "offenses"]
+        "required": [
+          "subject",
+          "case_details",
+          "offenses"
+        ]
       },
       "CriminalReport": {
         "type": "object",
@@ -7650,7 +7994,12 @@
             }
           }
         },
-        "required": ["message", "disclaimer", "consumer_statement", "results"]
+        "required": [
+          "message",
+          "disclaimer",
+          "consumer_statement",
+          "results"
+        ]
       },
       "CreditReportHitCode": {
         "type": "object",
@@ -7666,7 +8015,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportPersonalData": {
         "type": "object",
@@ -7718,7 +8070,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportBankruptcyDetail": {
         "type": "object",
@@ -7815,13 +8170,19 @@
             "nullable": true
           }
         },
-        "required": ["inquirer", "date"]
+        "required": [
+          "inquirer",
+          "date"
+        ]
       },
       "CreditReportConsumerInformation": {
         "type": "object",
         "properties": {
           "other_names": {
-            "examples": ["John Doe", "JD"],
+            "examples": [
+              "John Doe",
+              "JD"
+            ],
             "nullable": true,
             "type": "array",
             "items": {
@@ -7943,7 +8304,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportCollection": {
         "type": "object",
@@ -8068,7 +8432,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportAccountType": {
         "type": "object",
@@ -8084,7 +8451,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportRate": {
         "type": "object",
@@ -8100,7 +8470,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportTermsDuration": {
         "type": "object",
@@ -8116,7 +8489,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportTermsFrequency": {
         "type": "object",
@@ -8132,7 +8508,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditorClassification": {
         "type": "object",
@@ -8148,7 +8527,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportPaymentHistory": {
         "type": "object",
@@ -8163,7 +8545,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportAccountOverview": {
         "type": "object",
@@ -8496,7 +8881,11 @@
             "nullable": true
           }
         },
-        "required": ["statement", "date_reported", "date_purged"]
+        "required": [
+          "statement",
+          "date_reported",
+          "date_purged"
+        ]
       },
       "CreditReportType": {
         "type": "object",
@@ -8512,7 +8901,10 @@
             "nullable": true
           }
         },
-        "required": ["code", "description"]
+        "required": [
+          "code",
+          "description"
+        ]
       },
       "CreditReportAlertContact": {
         "type": "object",
@@ -8541,7 +8933,10 @@
             "nullable": true
           },
           "phone_numbers": {
-            "examples": ["(504) 113-1705", "(504) 113-1705"],
+            "examples": [
+              "(504) 113-1705",
+              "(504) 113-1705"
+            ],
             "nullable": true,
             "type": "array",
             "items": {
@@ -8710,7 +9105,12 @@
             "example": "John"
           }
         },
-        "required": ["email", "phone", "last_name", "first_name"]
+        "required": [
+          "email",
+          "phone",
+          "last_name",
+          "first_name"
+        ]
       },
       "IncomeVerificationPreTaxIncome": {
         "type": "object",
@@ -8723,7 +9123,10 @@
             "example": 1000
           }
         },
-        "required": ["income_type", "income_amount"]
+        "required": [
+          "income_type",
+          "income_amount"
+        ]
       },
       "IncomeVerificationMethod": {
         "type": "object",
@@ -8739,7 +9142,10 @@
             "example": "Paystub"
           }
         },
-        "required": ["pay_stub_files", "verification_type"]
+        "required": [
+          "pay_stub_files",
+          "verification_type"
+        ]
       },
       "IncomeVerificationEmployment": {
         "type": "object",
@@ -8794,7 +9200,11 @@
             "$ref": "#/components/schemas/Money"
           }
         },
-        "required": ["employment", "income_source", "monthly_income"]
+        "required": [
+          "employment",
+          "income_source",
+          "monthly_income"
+        ]
       },
       "IncomeVerificationReport": {
         "type": "object",
@@ -8840,7 +9250,11 @@
             "example": "USD"
           }
         },
-        "required": ["amount", "iso_currency_code", "unofficial_currency_code"]
+        "required": [
+          "amount",
+          "iso_currency_code",
+          "unofficial_currency_code"
+        ]
       },
       "VerifiedTransaction": {
         "type": "object",
@@ -8946,13 +9360,18 @@
             "example": "Value"
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "VerifiedBankOwner": {
         "type": "object",
         "properties": {
           "names": {
-            "example": ["John", "Doe"],
+            "example": [
+              "John",
+              "Doe"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -8980,7 +9399,12 @@
             }
           }
         },
-        "required": ["names", "emails", "addresses", "phone_numbers"]
+        "required": [
+          "names",
+          "emails",
+          "addresses",
+          "phone_numbers"
+        ]
       },
       "VerifiedBankIncomeSource": {
         "type": "object",
@@ -9144,7 +9568,9 @@
             "example": "123"
           },
           "routing_numbers": {
-            "example": ["123"],
+            "example": [
+              "123"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -9304,7 +9730,9 @@
             "example": "Bank"
           },
           "flow_types": {
-            "example": ["payroll_digital_income"],
+            "example": [
+              "payroll_digital_income"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -9582,7 +10010,12 @@
             "description": "Bank routing number"
           }
         },
-        "required": ["id", "name", "last4", "routing_number"]
+        "required": [
+          "id",
+          "name",
+          "last4",
+          "routing_number"
+        ]
       },
       "SetBankAccountRequest": {
         "type": "object",
@@ -9594,7 +10027,9 @@
             "description": "The ID of the bank account to associate with the property"
           }
         },
-        "required": ["bank_account_id"]
+        "required": [
+          "bank_account_id"
+        ]
       },
       "Lead": {
         "type": "object",
@@ -9690,7 +10125,11 @@
             "example": "2021-01-01T00:00:00.000Z"
           }
         },
-        "required": ["id", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateLeadRequest": {
         "type": "object",
@@ -9727,7 +10166,9 @@
             "nullable": true
           }
         },
-        "required": ["unit_id"]
+        "required": [
+          "unit_id"
+        ]
       },
       "BulkCreateLeadsRequest": {
         "type": "object",
@@ -9741,14 +10182,19 @@
             }
           }
         },
-        "required": ["leads"]
+        "required": [
+          "leads"
+        ]
       },
       "BulkCreateLeadResult": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["success", "error"],
+            "enum": [
+              "success",
+              "error"
+            ],
             "example": "success"
           },
           "lead": {
@@ -9776,7 +10222,9 @@
             }
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "UpdateLeadRequest": {
         "type": "object",
@@ -9859,7 +10307,14 @@
             "example": "2021-01-01T00:00:00.000Z"
           }
         },
-        "required": ["id", "name", "source_type", "is_active", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "name",
+          "source_type",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateLeadSourceRequest": {
         "type": "object",
@@ -9874,7 +10329,9 @@
             "default": true
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "Stage": {
         "type": "object",
@@ -9900,7 +10357,13 @@
             "example": 1
           }
         },
-        "required": ["id", "name", "color", "is_fixed", "position"]
+        "required": [
+          "id",
+          "name",
+          "color",
+          "is_fixed",
+          "position"
+        ]
       },
       "LeadActivityLog": {
         "type": "object",
@@ -10152,10 +10615,140 @@
                 "example": 400
               }
             },
-            "required": ["message", "status"]
+            "required": [
+              "message",
+              "status"
+            ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
+      },
+      "LeadIdentityVerificationChecks": {
+        "type": "object",
+        "properties": {
+          "basic": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "KYC check result. true = passed, false = failed, null = not run"
+          },
+          "document": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Documentary verification result"
+          },
+          "risk": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Risk check result"
+          },
+          "identity_abuse": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "synthetic_identity": {
+                "type": "object",
+                "properties": {
+                  "score": {
+                    "type": "number"
+                  },
+                  "passed": {
+                    "type": "boolean"
+                  },
+                  "risk_level": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ]
+                  }
+                }
+              },
+              "stolen_identity": {
+                "type": "object",
+                "properties": {
+                  "score": {
+                    "type": "number"
+                  },
+                  "passed": {
+                    "type": "boolean"
+                  },
+                  "risk_level": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "LeadIdentityVerification": {
+        "type": "object",
+        "properties": {
+          "lead_id": {
+            "type": "string",
+            "description": "Obfuscated lead ID"
+          },
+          "lead_external_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "External ID of the lead as provided by the partner"
+          },
+          "provider": {
+            "type": "string",
+            "example": "plaid",
+            "description": "IDV provider"
+          },
+          "kind": {
+            "type": "string",
+            "example": "automatic",
+            "description": "Type of identity verification"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "active",
+              "finished",
+              "failed",
+              "review_required",
+              "canceled",
+              "expired"
+            ],
+            "description": "Current status of the identity verification"
+          },
+          "finished_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when verification was finished"
+          },
+          "failed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when verification failed"
+          },
+          "checks": {
+            "$ref": "#/components/schemas/LeadIdentityVerificationChecks",
+            "description": "Individual check results"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### Related ticket

https://boompay.atlassian.net/browse/CRM-653

### Description

Add API documentation for the new `GET /partner/v1/leads/identity_verifications` endpoint.

- New endpoint with pagination params (`page`, `per_page`)
- New schema `LeadIdentityVerification` with fields: `lead_id`, `lead_external_id`, `provider`, `kind`, `status`, `finished_at`, `failed_at`, `checks`, timestamps
- New schema `LeadIdentityVerificationChecks` with fields: `basic`, `document`, `risk`, `identity_abuse`

### Release tester notes

https://github.com/boompay/boompay-api/pull/4162