### PR TITLE
Fix: screening applications status query param as array

### DIFF
--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -1797,11 +1797,14 @@
             }
           },
           {
-            "name": "status",
+            "name": "status[]",
             "required": false,
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           {


### PR DESCRIPTION
## Related ticket

N/A

## Description

- GET `/partner/v1/applications`: changed the `status` query parameter from a scalar string to an array named `status[]`.
- Swagger UI now serializes `?status[]=approved` (and multi-value `?status[]=approved&status[]=rejected`), which the Grape backend parses correctly.
- Previously the spec advertised `?status=approved` (scalar), which the backend rejects with `400 "status is invalid"` because the endpoint expects an array; only `status[]=` yields a proper array (a plain repeated `status=a&status=b` makes Grape keep just the last value).

## Release tester notes

- In Swagger UI "Try it out" on GET `/partner/v1/applications`, set a status value and confirm the request is sent as `status[]=approved` and returns 200 instead of the previous 400.