### PR TITLE
add GET /partner/v1/listings endpoint

### DIFF
--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -11008,9 +11008,9 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "example": 12345,
-            "description": "Boom listing ID."
+            "type": "string",
+            "description": "Obfuscated Boom listing ID.",
+            "example": "aB3xQ9pL"
           },
           "title": {
             "type": "string",
@@ -11104,11 +11104,6 @@
             "description": "Public listing page URL - the same URL included in the partner's generic XML feed."
           },
           "content_changed_at": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "last_updated": {
             "type": "string",
             "format": "date-time",
             "nullable": true

--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -5046,6 +5046,70 @@
         ],
         "security": []
       }
+    },
+    "/partner/v1/listings": {
+      "get": {
+        "operationId": "ListingsController_findAll",
+        "summary": "List active listings",
+        "description": "Returns the authenticated partner's own active listings only - never another partner's data. Data matches the partner's generic XML feed (active listing whose unit is listed), including the Apply Now, Contact Us, and Request Showing action links. No filter/query parameters are supported in v1 beyond pagination; for a property-scoped API key, results are further restricted to the properties in scope.",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "per_page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedResponse"
+                    },
+                    {
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/PartnerListing"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "Listings"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
     }
   },
   "info": {
@@ -10921,6 +10985,149 @@
             "description": "The partner's URL slug, echoed back from the request."
           }
         }
+      },
+      "PartnerListingActionLinks": {
+        "type": "object",
+        "description": "Lead-capture links for this listing, matching the links included in the partner's generic XML feed. A key is present only when the listing template enables that action; keys for disabled actions are omitted entirely (not null).",
+        "properties": {
+          "apply_now": {
+            "type": "string",
+            "description": "The Apply Now magic link. Present only when the template enables Apply Now and a magic link exists for the unit."
+          },
+          "request_showing": {
+            "type": "string",
+            "description": "URL of the Request a Showing page. Present only when the template enables it."
+          },
+          "contact_us": {
+            "type": "string",
+            "description": "URL of the Contact Us page. Present only when the template enables it."
+          }
+        }
+      },
+      "PartnerListing": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 12345,
+            "description": "Boom listing ID."
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "example": "Sunny 2BR near downtown"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "example": "A great place to live"
+          },
+          "property_type": {
+            "type": "string",
+            "nullable": true,
+            "example": "single_family",
+            "description": "The listing's property kind."
+          },
+          "address": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              },
+              {
+                "properties": {
+                  "one_line_address": {
+                    "type": "string",
+                    "nullable": true,
+                    "example": "123 Main St, San Francisco, CA, 94103, US"
+                  }
+                }
+              }
+            ]
+          },
+          "monthly_rent_amount": {
+            "$ref": "#/components/schemas/Money"
+          },
+          "beds": {
+            "type": "number",
+            "nullable": true,
+            "example": 2
+          },
+          "baths": {
+            "type": "number",
+            "nullable": true,
+            "example": 1
+          },
+          "sqft": {
+            "type": "number",
+            "nullable": true,
+            "example": 800
+          },
+          "available_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "cats_allowed": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "dogs_allowed": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "primary_image_url": {
+            "nullable": true,
+            "description": "The listing's primary image. Shape varies by source: a plain URL string, an empty object when no image is set, or an object such as { \"full\": ..., \"small\": ... } or { \"url\": ..., \"alt\": ... }."
+          },
+          "gallery_urls": {
+            "type": "array",
+            "items": {},
+            "description": "Gallery images. Same variable per-item shape as primary_image_url."
+          },
+          "common_amenity_ids": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "special_feature_ids": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "listing_url": {
+            "type": "string",
+            "nullable": true,
+            "description": "Public listing page URL - the same URL included in the partner's generic XML feed."
+          },
+          "content_changed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "action_links": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartnerListingActionLinks"
+              }
+            ],
+            "nullable": true,
+            "description": "Null when the listing has no listing template (no lead-capture actions available)."
+          }
+        },
+        "required": [
+          "id",
+          "address",
+          "monthly_rent_amount"
+        ]
       }
     }
   }


### PR DESCRIPTION
### Related ticket

https://boompay.atlassian.net/browse/CRM-1081

### Description

Add API documentation for the new `GET /partner/v1/listings` endpoint.

- New endpoint with pagination params (`page`, `per_page`); no other filters in v1
- New schema `PartnerListing` with fields: `id`, `title`, `description`, `property_type`, `address`, `monthly_rent_amount`, `beds`, `baths`, `sqft`, `available_at`, `cats_allowed`, `dogs_allowed`, `primary_image_url`, `gallery_urls`, `common_amenity_ids`, `special_feature_ids`, `listing_url`, `content_changed_at`, `last_updated`, `action_links`
- New schema `PartnerListingActionLinks` with fields: `apply_now`, `request_showing`, `contact_us` (each present only when the listing template enables that action)

### Release tester notes

https://github.com/boompay/boompay-api/pull/4995