### PR TITLE
CRM-1106 | docs: add verification_last_updated_at field to Lead schema

### DIFF
--- a/screening-api-docs/api.json
+++ b/screening-api-docs/api.json
@@ -10207,6 +10207,13 @@
             "format": "date-time",
             "type": "string",
             "example": "2021-01-01T00:00:00.000Z"
+          },
+          "verification_last_updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2021-01-01T00:00:00.000Z",
+            "nullable": true,
+            "description": "Timestamp of the most recent identity verification activity (created or completed) for this lead. Null if no verification has occurred. Tracked separately from updated_at, which only reflects direct edits to the lead."
           }
         },
         "required": [


### PR DESCRIPTION
### Related ticket

https://boompay.atlassian.net/browse/CRM-1106

### Description

Adds `verification_last_updated_at` to the `Lead` schema in the Partner API (Screening API) docs, matching the field just added to `Boom::PartnerAPI::Lead::BaseEntity` in `boompay-api` (see boompay/boompay-api#5077).

- Nullable `date-time` field, placed right after `updated_at`.
- Description explains it tracks the most recent identity verification activity (created/completed) for the lead, separate from `updated_at`, which only reflects direct edits to the lead itself.

### Release tester notes

Docs-only change — no code/runtime behavior to test here. Verify the rendered Lead schema (wherever this OpenAPI spec is published/viewed) shows `verification_last_updated_at` with the description above.